### PR TITLE
Fix footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,9 +381,9 @@
         <div class="container">
             <div class="footer-bottom-content d-flex flex-column flex-lg-row align-items-center justify-content-between">
                 <div class="footer-links py-2 d-flex flex-column flex-sm-row align-items-center gap-2 gap-sm-3">
-                    <a href="#" class="footer-link" data-translate="footer.link1" translate-href="footer.link1Href"></a>
-                    <a href="#" class="footer-link" data-translate="footer.link2" translate-href="footer.link2Href"></a>
-                    <a href="#" class="footer-link" data-translate="footer.link3" translate-href="footer.link3Href"></a>
+                    <a href="#" class="footer-link" data-translate="footer.link1" data-translate-href="footer.link1Href"></a>
+                    <a href="#" class="footer-link" data-translate="footer.link2" data-translate-href="footer.link2Href"></a>
+                    <a href="#" class="footer-link" data-translate="footer.link3" data-translate-href="footer.link3Href"></a>
                 </div>
                 <div class="d-flex flex-column flex-lg-row align-items-center">
                     <div class="copyright-text text-center text-lg-end py-2 me-lg-3" data-translate="footer.rightsReserved"></div>


### PR DESCRIPTION
To make the footer links use the correct translated URLs, instead of `#`.